### PR TITLE
update parser to support go 1.15

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -1507,6 +1507,40 @@ var testCases = []TestCase{
 			},
 		},
 	},
+	{
+		name:       "32-go-1.15-output.txt",
+		reportName: "32-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name:     "package/name",
+					Duration: 151 * time.Millisecond,
+					Time:     151,
+					Tests: []*parser.Test{
+						{
+							Name:     "TestOne",
+							Duration: 20 * time.Millisecond,
+							Time:     20,
+							Result:   parser.FAIL,
+							Output: []string{
+								"file_test.go:11: Error message",
+								"file_test.go:11: Longer",
+								"\terror",
+								"\tmessage.",
+							},
+						},
+						{
+							Name:     "TestTwo",
+							Duration: 130 * time.Millisecond,
+							Time:     130,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestParser(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -221,6 +221,7 @@ func Parse(r io.Reader, pkgName string) (*Report, error) {
 			if test == nil {
 				continue
 			}
+			buffers[cur] = append(buffers[cur], line)
 			test.Output = append(test.Output, matches[2])
 		} else if strings.HasPrefix(line, "# ") {
 			// indicates a capture of build output of a package. set the current build package.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -221,7 +221,7 @@ func Parse(r io.Reader, pkgName string) (*Report, error) {
 			if test == nil {
 				continue
 			}
-			buffers[cur] = append(buffers[cur], line)
+			buffers[cur] = append(buffers[cur], matches[2])
 			test.Output = append(test.Output, matches[2])
 		} else if strings.HasPrefix(line, "# ") {
 			// indicates a capture of build output of a package. set the current build package.

--- a/testdata/32-go-1.15-output.txt
+++ b/testdata/32-go-1.15-output.txt
@@ -1,0 +1,11 @@
+=== RUN TestOne
+    	file_test.go:11: Error message
+    	file_test.go:11: Longer
+    		error
+    		message.
+--- FAIL: TestOne (0.02 seconds)
+=== RUN TestTwo
+--- PASS: TestTwo (0.13 seconds)
+FAIL
+exit status 1
+FAIL	package/name 0.151s

--- a/testdata/32-report.xml
+++ b/testdata/32-report.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="2" failures="1" time="0.151" name="package/name">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="name" name="TestOne" time="0.020">
+			<failure message="Failed" type="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;&#x9;error&#xA;&#x9;message.</failure>
+		</testcase>
+		<testcase classname="name" name="TestTwo" time="0.130"></testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
With `go 1.15`, the location of the `--- FAIL:` message changed:

old:
```
=== RUN   TestRunCommandWithOptionsSuccess
--- FAIL: TestRunCommandWithOptionsSuccess (0.01s)
    local_test.go:33: 
        	Error Trace:	local_test.go:33
        	Error:      	Not equal: 
        	            	expected: "foofooasdf\n"
        	            	actual  : "foofoo\n"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,2 @@
        	            	-foofooasdf
        	            	+foofoo
        	            	 
        	Test:       	TestRunCommandWithOptionsSuccess
=== RUN   TestRunCommandWithOptionsOutputNZEC
```
new:
```
=== RUN   TestRunCommandWithOptionsSuccess
    local_test.go:33: 
        	Error Trace:	local_test.go:33
        	Error:      	Not equal: 
        	            	expected: "foofooasdf\n"
        	            	actual  : "foofoo\n"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,2 @@
        	            	-foofooasdf
        	            	+foofoo
        	            	 
        	Test:       	TestRunCommandWithOptionsSuccess
--- FAIL: TestRunCommandWithOptionsSuccess (0.00s)
=== RUN   TestRunCommandWithOptionsOutputNZEC
```

The parse classifies the `local_test.go:33` in this branch: https://github.com/jeeyoungk/go-junit-report/blob/master/parser/parser.go#L243-L252, and the rest of the output in this branch: https://github.com/jeeyoungk/go-junit-report/blob/master/parser/parser.go#L217-L224

Since the second branch doesn't append to `buffers[cur]`, when the `--- FAIL:` was detected, it would overwrite `test.Output` with the `buffer[cur]`, which only contained that first line (`local_test.go:33`), thus causing the junit xml to only contain the first line of output.

By appending to `buffers[cur]` in this branch: https://github.com/jeeyoungk/go-junit-report/blob/master/parser/parser.go#L217-L224, we fix this problem.

I also added a test case for this: https://github.com/jarrodddunne/go-junit-report/blob/master/testdata/32-go-1.15-output.txt, which is the same as https://github.com/jarrodddunne/go-junit-report/blob/master/testdata/02-fail.txt but with the `---FAIL` line afterwards.